### PR TITLE
Fix special character bug

### DIFF
--- a/Scripts/Settings.ps1
+++ b/Scripts/Settings.ps1
@@ -1,7 +1,7 @@
 # Configure the variables below that will be used in the script
-$HAToken = "" # Example: eyJ0eXAiOiJKV1...
+$HAToken = '' # Example: eyJ0eXAiOiJKV1...
 $UserName = "" # When not sure, open a command prompt and type: echo %USERNAME%
-$UserPass = "" # This is the same password you would use to login to Office.com
+$UserPass = '' # This is the same password you would use to login to Office.com
 $HAUrl = "" # Example: https://yourha.duckdns.org
 
 # Set language variables below


### PR DESCRIPTION
When using double ticks you'll get problems if the token or password contains special characters like "$": [explained here](https://documentation.n-able.com/remote-management/userguide/Content/vmware_esxi_powershell_passwords.htm#:~:text=For%20example%2C%20if%20the%20password,to%20PowerShell%20exactly%20as%20entered.)